### PR TITLE
slidev-template: Update slidev-template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 components.d.ts
 .vite
 .venv
+vite.config.ts

--- a/slides-template.md
+++ b/slides-template.md
@@ -1,0 +1,22 @@
+---
+theme: ./theme
+background: /intro.png
+# some information about your slides (markdown enabled)
+title: Zarhus Developer Meetup
+info: false
+# apply unocss classes to the current slide
+class: text-center
+# https://sli.dev/features/drawing
+drawings:
+  persist: false
+# slide transition: https://sli.dev/guide/animations.html#slide-transitions
+transition: slide-left
+# enable MDC Syntax: https://sli.dev/features/mdc
+mdc: true
+---
+
+## Zarhus Developer Meetup
+
+---
+src: <SRC>
+---


### PR DESCRIPTION
Use <https://github.com/3mdeb/slidev-template/pull/14> version. Can't manage to render slides with current one.